### PR TITLE
Remove unnecessary mjai messages for bots

### DIFF
--- a/game/game_state.py
+++ b/game/game_state.py
@@ -243,13 +243,6 @@ class GameState:
             return None
         self.seat = seatList.index(self.account_id)
         self.mjai_bot.init_bot(self.seat)
-        self.mjai_pending_input_msgs.append(
-            {
-                'type': MJAI_TYPE.START_GAME,
-                'id': self.seat
-            }
-        )        
-        self._react_all()
         return None     # no reaction for start_game     
     
     def ms_new_round(self, liqi_data:dict) -> dict:
@@ -542,12 +535,6 @@ class GameState:
     def ms_end_kyoku(self) -> dict | None:
         """ End kyoku and get None as reaction"""
         self.mjai_pending_input_msgs = []
-        self.mjai_pending_input_msgs.append(
-            {
-                'type': MJAI_TYPE.END_KYOKU
-            }
-        )
-        self._react_all()
         return None     # no reaction for end_kyoku
     
         
@@ -557,12 +544,6 @@ class GameState:
             # process end result
             pass
         
-        self.mjai_pending_input_msgs.append(
-            {
-                'type': MJAI_TYPE.END_GAME
-            }
-        )
-        self._react_all()
         self.is_game_ended = True
         return None     # no reaction for end_game
     


### PR DESCRIPTION
According to the source code of `libriichi`, the messages of types `start_game`, `end_kyoku`, and `end_game` are never used. Initial state info for each kyoku is included in the `start_kyoku` event.

`libriichi` does nothing when receiving the `end_kyoku` or `end_game` message, without any clean up of states. It also does not use anything from the `start_game` event. (`start_game`'s `id` field is not included in the internal structure of this event, so the seat id must be specified in the bot initialization.)