### PR TITLE
Workaround for Linux

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -180,7 +180,7 @@ def is_certificate_installed(cert_file:str) -> tuple[bool, str]:
                 'text': True,
                 'check': False}
         else:   # unsupported platform
-            return False
+            return True, "Unsupported platform"
         result = subprocess.run(cmd, **args)    #pylint:disable=subprocess-run-check
         # Check if the command output indicates the certificate was found
         if result.returncode==0:


### PR DESCRIPTION
Linux users should be able to install CA on their own.