### PR TITLE
✨ feat: Compatible with MajsoulMax & 🐛 fix: Subprogress bug in macOS

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -125,7 +125,10 @@ class BotManager:
     def start_browser(self):
         """ Start the browser thread, open browser window """
         ms_url = self.st.ms_url
-        proxy = self.mitm_server.proxy_str
+        if self.st.majsoulmax_proxy:
+            proxy = self.st.majsoulmax_proxy
+        else:
+            proxy = self.mitm_server.proxy_str
         self.browser.start(ms_url, proxy, self.st.browser_width, self.st.browser_height, self.st.enable_chrome_ext)
     
     def is_browser_zoom_off(self):

--- a/common/settings.py
+++ b/common/settings.py
@@ -30,6 +30,7 @@ class Settings:
         self.inject_process_name:str = self._get_value("inject_process_name", "jantama_mahjongsoul")
         self.language:str = self._get_value("language", list(LAN_OPTIONS.keys())[-1], self.valid_language)  # language code
         self.enable_overlay:bool = self._get_value("enable_overlay", True, self.valid_bool) # not shown
+        self.majsoulmax_proxy:str = self._get_value("majsoulmax_proxy", "")
         
         # AI Model settings
         self.model_type:str = self._get_value("model_type", "Local")

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,23 @@ python main.py
 ### Model Configuration
 This program supports different types of AI models. The 'Local' Model type uses Mortal models compatible with Akagi. To acquire Akagi's models, please refer to <a href="https://github.com/shinkuan/Akagi" target="_blank"> Akagi Github </a>.
 
+### 与 MajsoulMax 搭配使用
+
+如果你想要和 [MajsoulMax](https://github.com/Avenshy/MajsoulMax) 搭配使用，请在 `settings.json` 中设置 `"majsoulmax_proxy": "http://127.0.0.1:23410"` 。
+
+随后，请以如下方式启动 MajsoulMax：
+
+```bash
+mitmdump -p 23410 --mode upstream:http://127.0.0.1:10999 -s addons.py --ssl-insecure
+```
+
+请注意，如果你修改了 MajsoulMax 或者 MahjangCopilot 的代理端口，请相应修改对应端口，并且确保 MajsoulMax 和 MahjangCopilot 的自签名证书均正确安装（这两者是不同的，前者默认使用 `~/.mitmproxy/` 下的证书，而后者使用 `./mitm_config/` 下的证书）。
+
+最终代理链为：
+
+```
+Program -> MajsoulMax(23410) -> MahjongCopilot(10999) -> Server
+```
 
 ## 截图 / Screenshots
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pillow
 riichi>=0.1.1
 tkhtmlview
 pyinstaller
-
+cryptography


### PR DESCRIPTION
如题。

关于 MajsoulMax 的说明：我尝试了颠倒代理顺序，使用现有的 upstream_proxy 来完成（即 Program -> MahjongCopilot(10999) -> MajsoulMax(23410) -> Server），但发现会出现如下表现：

1. 能进游戏，能解锁
2. 能识别手牌，但无法启动 AI 计算

所以我将 MajsoulMax 前置了以正确完成整个流程，这导致需要修改本仓库的代码，以及 settings.json 的设置项。

关于 subprogress 的说明：

注意到 https://github.com/latorc/MahjongCopilot/issues/59#issuecomment-2995935585 这里的说明，发现非 Windows 下没有 `subprocess.STARTUPINFO()` 这一属性，进而导致判断证书存在失败，永远都要输密码，所以这里需要特判；然后由于 mitmproxy 没有采用默认的路径 ~/.mitmproxy 下的证书，所以需要对比指纹而不是仅仅对比 CN 来确保证书安装成功，故新增一个依赖项。

同时，参考 https://github.com/latorc/MahjongCopilot/issues/59#issuecomment-2511206628 ，建议锁一下 numpy 的版本，macOS 上锁定后正常，但未在 Windows 上测试，所以暂时没有修改。

相关 Issue：

- https://github.com/latorc/MahjongCopilot/issues/59
- https://github.com/latorc/MahjongCopilot/issues/39
- https://github.com/latorc/MahjongCopilot/issues/66